### PR TITLE
Added feature to set the template settings in doT

### DIFF
--- a/express-dot.js
+++ b/express-dot.js
@@ -89,3 +89,7 @@ exports.__express = function(filename, options, cb) {
     return _renderWithLayout(filename, layoutTemplate, options, cb);
   });
 };
+
+exports.setTemplateSettings = function(settings) {
+	doT.templateSettings = settings;
+};


### PR DESCRIPTION
doT allows the override of default template settings, including setting the stripping of whitespace, changing the regexes used to match templating keywords, and more. I added a function called setTemplateSettings which will allow access to change that in express-dot since there was no publicly available method to do so.
